### PR TITLE
Fixed powercost for #187

### DIFF
--- a/epc/index.html
+++ b/epc/index.html
@@ -2124,7 +2124,7 @@
     Set5 #185;; 9SS; Acantha, the Huntress;
 
     Set5 #186;; 4FFTT; Darya, Warrior Poet;
-    Set5 #187;; 4FT; Stoneshell Walker;
+    Set5 #187;; 5FT; Stoneshell Walker;
     Set5 #188;; 4TJ; Penitent Bull;
     Set5 #189;; 5TTJJ; Serene Meditant;
     Set5 #190;; 5JJPP; Aniyah, Arctic Sheriff;


### PR DESCRIPTION
Powercost for Stoneshell Walker#187 from 4FT to its actual cost 5FT